### PR TITLE
Update Ownable contract for Ethereum compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,7 @@ license = "MIT"
 cosmwasm-std = "1.0.0"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_with = "2.0.1"
-blake2 = "0.10.6"
-sha2 = "0.10.6"
 bs58 = "0.4.0"
-secp256k1 = "0.26.0"
-hex = "0.4.3"
-sha3 = "0.7.2"
 schemars = "0.8.8"
 wasm-bindgen = { version = "0.2.63", features = ["serde-serialize"] }
 serde_json = "1.0.59"


### PR DESCRIPTION
## Summary
-Removed the public-key-based address conversion helpers and related imports so the library now relies solely on address values for its utilities.
- Trimmed cryptographic dependencies that were only needed for those conversions from the crate manifest.
- rename `create_lto_env` to `create_env` and require the caller to supply the target chain id with an optional block time
- rename `load_lto_deps` to `load_owned_deps` to better reflect the helper's purpose

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d52473e88c8320af00d64bc8d50d02