### PR TITLE
feat: add dossier attachment and close surface

### DIFF
--- a/macros/ownable-std-macros/src/lib.rs
+++ b/macros/ownable-std-macros/src/lib.rs
@@ -4,295 +4,245 @@ use syn::{
     parse::Nothing,
     parse_macro_input,
     Data::{Enum, Struct},
-    DataEnum, DataStruct, DeriveInput, FieldsNamed,
+    DataEnum, DataStruct, DeriveInput, FieldsNamed, Variant,
 };
 
-/// Adds `Transfer { to: Addr }` to an `ExecuteMsg` enum.
-#[proc_macro_attribute]
-pub fn ownables_transfer(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
-    parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_execute_variants: TokenStream = quote! {
-        enum ExecuteMsg {
-            Transfer {to: Addr},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_execute_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
+fn variants_from(
+    tokens: proc_macro2::TokenStream,
+) -> syn::Result<syn::punctuated::Punctuated<Variant, syn::token::Comma>> {
+    let default_ast: DeriveInput = syn::parse2(tokens)?;
+    match default_ast.data {
+        Enum(DataEnum { variants, .. }) => Ok(variants),
         _ => panic!("only enums can provide variants"),
-    };
+    }
+}
 
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
+fn extend_enum_with_variants_impl(
+    input: proc_macro2::TokenStream,
+    default_variants: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let mut input_ast: DeriveInput = syn::parse2(input).expect("parse input enum");
+    let variants = variants_from(default_variants).expect("parse default variants");
     let input_variants_data = match &mut input_ast.data {
         Enum(DataEnum { variants, .. }) => variants,
         _ => panic!("only enums can accept variants"),
     };
+    input_variants_data.extend(variants);
+    quote! { #input_ast }
+}
 
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
+fn ownables_attach_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum ExecuteMsg {
+                Attach { attachments: Vec<AttachmentInput> },
+            }
+        },
+    )
+    .into()
+}
 
-    quote! { #input_ast }.into()
+fn ownables_close_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum ExecuteMsg {
+                Close {},
+            }
+        },
+    )
+    .into()
+}
+
+fn ownables_query_attachments_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum QueryMsg {
+                GetAttachments {},
+            }
+        },
+    )
+    .into()
+}
+
+fn ownables_query_closed_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum QueryMsg {
+                IsClosed {},
+            }
+        },
+    )
+    .into()
+}
+
+/// Adds `Transfer { to: Addr }` to an `ExecuteMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_transfer(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum ExecuteMsg {
+                Transfer {to: Addr},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `Lock {}` to an `ExecuteMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_lock(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_execute_variants: TokenStream = quote! {
-        enum ExecuteMsg {
-            Lock {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_execute_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum ExecuteMsg {
+                Lock {},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `Consume {}` to an `ExecuteMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_consume(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum ExecuteMsg {
+                Consume {},
+            }
+        },
+    )
+    .into()
+}
 
-    // define the variants to be inserted and parse into DataEnum
-    let default_execute_variants: TokenStream = quote! {
-        enum ExecuteMsg {
-            Consume {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_execute_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
+/// Adds `Attach { attachments: Vec<AttachmentInput> }` to an `ExecuteMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_attach(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    ownables_attach_impl(input.into()).into()
+}
 
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+/// Adds `Close {}` to an `ExecuteMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_close(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    ownables_close_impl(input.into()).into()
 }
 
 /// Adds `GetMetadata {}` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_metadata(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            GetMetadata {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                GetMetadata {},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `GetInfo {}` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_info(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            GetInfo {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                GetInfo {},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `GetWidgetState {}` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_widget_state(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            GetWidgetState {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                GetWidgetState {},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `IsLocked {}` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_locked(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            IsLocked {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                IsLocked {},
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds `IsConsumed {}` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_consumed(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                IsConsumed {},
+            }
+        },
+    )
+    .into()
+}
 
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            IsConsumed {},
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
+/// Adds `GetAttachments {}` to a `QueryMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_query_attachments(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    ownables_query_attachments_impl(input.into()).into()
+}
 
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+/// Adds `IsClosed {}` to a `QueryMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_query_closed(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    ownables_query_closed_impl(input.into()).into()
 }
 
 /// Adds `IsConsumerOf { issuer: Addr, consumable_type: String }` to a `QueryMsg` enum.
 #[proc_macro_attribute]
 pub fn ownables_query_consumer_of(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
-
-    // define the variants to be inserted and parse into DataEnum
-    let default_query_variants: TokenStream = quote! {
-        enum QueryMsg {
-            IsConsumerOf {
-                issuer: Addr,
-                consumable_type: String,
-            },
-        }
-    }
-    .into();
-    let default_ast: DeriveInput = parse_macro_input!(default_query_variants);
-    let default_variants = match default_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can provide variants"),
-    };
-
-    // parse the input variants
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_variants_data = match &mut input_ast.data {
-        Enum(DataEnum { variants, .. }) => variants,
-        _ => panic!("only enums can accept variants"),
-    };
-
-    // insert variants from the default to input
-    input_variants_data.extend(default_variants.into_iter());
-
-    quote! { #input_ast }.into()
+    extend_enum_with_variants_impl(
+        input.into(),
+        quote! {
+            enum QueryMsg {
+                IsConsumerOf {
+                    issuer: Addr,
+                    consumable_type: String,
+                },
+            }
+        },
+    )
+    .into()
 }
 
 /// Adds default ownables fields to an `InstantiateMsg` struct:
@@ -305,10 +255,8 @@ pub fn ownables_query_consumer_of(metadata: TokenStream, input: TokenStream) -> 
 /// }
 #[proc_macro_attribute]
 pub fn ownables_instantiate_msg(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    // validate no input args
     parse_macro_input!(metadata as Nothing);
 
-    // define the fields to be inserted and parse into DataEnum
     let default_instantiate_fields: TokenStream = quote! {
         struct InstantiateMsg {
             pub ownable_id: String,
@@ -332,10 +280,99 @@ pub fn ownables_instantiate_msg(metadata: TokenStream, input: TokenStream) -> To
         _ => panic!("only structs can accept fields"),
     };
 
-    // push the default fields onto the input
     if let syn::Fields::Named(FieldsNamed { named, .. }) = input_fields_data {
         named.extend(default_fields);
     }
 
     quote! { #input_ast }.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::ToTokens;
+    use syn::{Data, Fields};
+
+    fn parse_enum(input: proc_macro2::TokenStream) -> syn::DataEnum {
+        let parsed: DeriveInput = syn::parse2(input).expect("parse enum");
+        match parsed.data {
+            Data::Enum(data) => data,
+            _ => panic!("expected enum"),
+        }
+    }
+
+    fn find_variant<'a>(data: &'a syn::DataEnum, name: &str) -> &'a Variant {
+        data.variants
+            .iter()
+            .find(|variant| variant.ident == name)
+            .unwrap_or_else(|| panic!("missing variant {name}"))
+    }
+
+    #[test]
+    fn ownables_attach_injects_attachment_input_vector() {
+        let data = parse_enum(ownables_attach_impl(quote! {
+            enum ExecuteMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "Attach");
+
+        match &variant.fields {
+            Fields::Named(fields) => {
+                assert_eq!(fields.named.len(), 1);
+                let field = &fields.named[0];
+                assert_eq!(field.ident.as_ref().expect("named field"), "attachments");
+                assert_eq!(
+                    field.ty.to_token_stream().to_string(),
+                    "Vec < AttachmentInput >"
+                );
+            }
+            _ => panic!("Attach should have named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_close_injects_close_variant() {
+        let data = parse_enum(ownables_close_impl(quote! {
+            enum ExecuteMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "Close");
+
+        match &variant.fields {
+            Fields::Named(fields) => assert!(fields.named.is_empty()),
+            _ => panic!("Close should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_query_attachments_injects_get_attachments_variant() {
+        let data = parse_enum(ownables_query_attachments_impl(quote! {
+            enum QueryMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "GetAttachments");
+
+        match &variant.fields {
+            Fields::Named(fields) => assert!(fields.named.is_empty()),
+            _ => panic!("GetAttachments should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_query_closed_injects_is_closed_variant() {
+        let data = parse_enum(ownables_query_closed_impl(quote! {
+            enum QueryMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "IsClosed");
+
+        match &variant.fields {
+            Fields::Named(fields) => assert!(fields.named.is_empty()),
+            _ => panic!("IsClosed should use named fields"),
+        }
+    }
 }

--- a/macros/ownable-std-macros/src/lib.rs
+++ b/macros/ownable-std-macros/src/lib.rs
@@ -79,12 +79,9 @@ fn ownables_query_closed_impl(input: proc_macro2::TokenStream) -> proc_macro2::T
     .into()
 }
 
-/// Adds `Transfer { to: Addr }` to an `ExecuteMsg` enum.
-#[proc_macro_attribute]
-pub fn ownables_transfer(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    parse_macro_input!(metadata as Nothing);
+fn ownables_transfer_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     extend_enum_with_variants_impl(
-        input.into(),
+        input,
         quote! {
             enum ExecuteMsg {
                 Transfer {to: Addr},
@@ -92,6 +89,82 @@ pub fn ownables_transfer(metadata: TokenStream, input: TokenStream) -> TokenStre
         },
     )
     .into()
+}
+
+fn ownables_query_info_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum QueryMsg {
+                GetInfo {},
+            }
+        },
+    )
+    .into()
+}
+
+fn ownables_query_consumed_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum QueryMsg {
+                IsConsumed {},
+            }
+        },
+    )
+    .into()
+}
+
+fn ownables_query_consumer_of_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    extend_enum_with_variants_impl(
+        input,
+        quote! {
+            enum QueryMsg {
+                IsConsumerOf {
+                    issuer: Addr,
+                    consumable_type: String,
+                },
+            }
+        },
+    )
+    .into()
+}
+
+fn ownables_instantiate_msg_impl(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    let default_instantiate_fields = quote! {
+        struct InstantiateMsg {
+            pub ownable_id: String,
+            pub package: String,
+            pub nft: Option<NFT>,
+            pub ownable_type: Option<String>,
+            pub network_id: u32,
+        }
+    };
+
+    let default_ast: DeriveInput = syn::parse2(default_instantiate_fields).expect("parse default struct");
+    let default_fields = match default_ast.data {
+        Struct(DataStruct { fields, .. }) => fields,
+        _ => panic!("only structs can accept fields"),
+    };
+
+    let mut input_ast: DeriveInput = syn::parse2(input).expect("parse input struct");
+    let input_fields_data = match &mut input_ast.data {
+        Struct(DataStruct { fields, .. }) => fields,
+        _ => panic!("only structs can accept fields"),
+    };
+
+    if let syn::Fields::Named(FieldsNamed { named, .. }) = input_fields_data {
+        named.extend(default_fields);
+    }
+
+    quote! { #input_ast }
+}
+
+/// Adds `Transfer { to: Addr }` to an `ExecuteMsg` enum.
+#[proc_macro_attribute]
+pub fn ownables_transfer(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    parse_macro_input!(metadata as Nothing);
+    ownables_transfer_impl(input.into()).into()
 }
 
 /// Adds `Lock {}` to an `ExecuteMsg` enum.
@@ -157,15 +230,7 @@ pub fn ownables_query_metadata(metadata: TokenStream, input: TokenStream) -> Tok
 #[proc_macro_attribute]
 pub fn ownables_query_info(metadata: TokenStream, input: TokenStream) -> TokenStream {
     parse_macro_input!(metadata as Nothing);
-    extend_enum_with_variants_impl(
-        input.into(),
-        quote! {
-            enum QueryMsg {
-                GetInfo {},
-            }
-        },
-    )
-    .into()
+    ownables_query_info_impl(input.into()).into()
 }
 
 /// Adds `GetWidgetState {}` to a `QueryMsg` enum.
@@ -202,15 +267,7 @@ pub fn ownables_query_locked(metadata: TokenStream, input: TokenStream) -> Token
 #[proc_macro_attribute]
 pub fn ownables_query_consumed(metadata: TokenStream, input: TokenStream) -> TokenStream {
     parse_macro_input!(metadata as Nothing);
-    extend_enum_with_variants_impl(
-        input.into(),
-        quote! {
-            enum QueryMsg {
-                IsConsumed {},
-            }
-        },
-    )
-    .into()
+    ownables_query_consumed_impl(input.into()).into()
 }
 
 /// Adds `GetAttachments {}` to a `QueryMsg` enum.
@@ -231,18 +288,7 @@ pub fn ownables_query_closed(metadata: TokenStream, input: TokenStream) -> Token
 #[proc_macro_attribute]
 pub fn ownables_query_consumer_of(metadata: TokenStream, input: TokenStream) -> TokenStream {
     parse_macro_input!(metadata as Nothing);
-    extend_enum_with_variants_impl(
-        input.into(),
-        quote! {
-            enum QueryMsg {
-                IsConsumerOf {
-                    issuer: Addr,
-                    consumable_type: String,
-                },
-            }
-        },
-    )
-    .into()
+    ownables_query_consumer_of_impl(input.into()).into()
 }
 
 /// Adds default ownables fields to an `InstantiateMsg` struct:
@@ -256,35 +302,7 @@ pub fn ownables_query_consumer_of(metadata: TokenStream, input: TokenStream) -> 
 #[proc_macro_attribute]
 pub fn ownables_instantiate_msg(metadata: TokenStream, input: TokenStream) -> TokenStream {
     parse_macro_input!(metadata as Nothing);
-
-    let default_instantiate_fields: TokenStream = quote! {
-        struct InstantiateMsg {
-            pub ownable_id: String,
-            pub package: String,
-            pub nft: Option<NFT>,
-            pub ownable_type: Option<String>,
-            pub network_id: u32,
-        }
-    }
-    .into();
-
-    let default_ast: DeriveInput = parse_macro_input!(default_instantiate_fields);
-    let default_fields = match default_ast.data {
-        Struct(DataStruct { fields, .. }) => fields,
-        _ => panic!("only structs can accept fields"),
-    };
-
-    let mut input_ast: DeriveInput = parse_macro_input!(input);
-    let input_fields_data = match &mut input_ast.data {
-        Struct(DataStruct { fields, .. }) => fields,
-        _ => panic!("only structs can accept fields"),
-    };
-
-    if let syn::Fields::Named(FieldsNamed { named, .. }) = input_fields_data {
-        named.extend(default_fields);
-    }
-
-    quote! { #input_ast }.into()
+    ownables_instantiate_msg_impl(input.into()).into()
 }
 
 #[cfg(test)]
@@ -306,6 +324,14 @@ mod tests {
             .iter()
             .find(|variant| variant.ident == name)
             .unwrap_or_else(|| panic!("missing variant {name}"))
+    }
+
+    fn parse_struct(input: proc_macro2::TokenStream) -> syn::DataStruct {
+        let parsed: DeriveInput = syn::parse2(input).expect("parse struct");
+        match parsed.data {
+            Data::Struct(data) => data,
+            _ => panic!("expected struct"),
+        }
     }
 
     #[test]
@@ -373,6 +399,116 @@ mod tests {
         match &variant.fields {
             Fields::Named(fields) => assert!(fields.named.is_empty()),
             _ => panic!("IsClosed should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_transfer_still_injects_addr_field() {
+        let data = parse_enum(ownables_transfer_impl(quote! {
+            enum ExecuteMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "Transfer");
+
+        match &variant.fields {
+            Fields::Named(fields) => {
+                assert_eq!(fields.named.len(), 1);
+                let field = &fields.named[0];
+                assert_eq!(field.ident.as_ref().expect("named field"), "to");
+                assert_eq!(field.ty.to_token_stream().to_string(), "Addr");
+            }
+            _ => panic!("Transfer should have named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_query_info_still_injects_get_info_variant() {
+        let data = parse_enum(ownables_query_info_impl(quote! {
+            enum QueryMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "GetInfo");
+
+        match &variant.fields {
+            Fields::Named(fields) => assert!(fields.named.is_empty()),
+            _ => panic!("GetInfo should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_query_consumed_still_injects_is_consumed_variant() {
+        let data = parse_enum(ownables_query_consumed_impl(quote! {
+            enum QueryMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "IsConsumed");
+
+        match &variant.fields {
+            Fields::Named(fields) => assert!(fields.named.is_empty()),
+            _ => panic!("IsConsumed should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_query_consumer_of_still_injects_expected_fields() {
+        let data = parse_enum(ownables_query_consumer_of_impl(quote! {
+            enum QueryMsg {
+                Existing {},
+            }
+        }));
+        let variant = find_variant(&data, "IsConsumerOf");
+
+        match &variant.fields {
+            Fields::Named(fields) => {
+                assert_eq!(fields.named.len(), 2);
+                assert_eq!(fields.named[0].ident.as_ref().expect("issuer"), "issuer");
+                assert_eq!(
+                    fields.named[0].ty.to_token_stream().to_string(),
+                    "Addr"
+                );
+                assert_eq!(
+                    fields.named[1].ident.as_ref().expect("consumable_type"),
+                    "consumable_type"
+                );
+                assert_eq!(
+                    fields.named[1].ty.to_token_stream().to_string(),
+                    "String"
+                );
+            }
+            _ => panic!("IsConsumerOf should use named fields"),
+        }
+    }
+
+    #[test]
+    fn ownables_instantiate_msg_still_injects_standard_fields() {
+        let data = parse_struct(ownables_instantiate_msg_impl(quote! {
+            struct InstantiateMsg {
+                pub name: String,
+            }
+        }));
+
+        match data.fields {
+            Fields::Named(fields) => {
+                let names: Vec<String> = fields
+                    .named
+                    .iter()
+                    .map(|field| field.ident.as_ref().expect("named field").to_string())
+                    .collect();
+                for required in [
+                    "name",
+                    "ownable_id",
+                    "ownable_type",
+                    "network_id",
+                    "package",
+                    "nft",
+                ] {
+                    assert!(names.iter().any(|name| name == required), "missing {required}");
+                }
+            }
+            _ => panic!("InstantiateMsg should use named fields"),
         }
     }
 }

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,0 +1,88 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Input payload for adding a named attachment by content address.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct AttachmentInput {
+    pub name: String,
+    pub cid: String,
+}
+
+/// A single attachment row returned from an ownable contract.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct Attachment {
+    pub name: String,
+    pub cid: String,
+}
+
+/// Response payload for attachment listing queries.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct GetAttachmentsResponse {
+    pub attachments: Vec<Attachment>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schemars::schema_for;
+    use serde_json::json;
+
+    #[test]
+    fn attachment_input_serializes_with_locked_field_names() {
+        let attachment = AttachmentInput {
+            name: "passport.pdf".to_string(),
+            cid: "bafybeihash".to_string(),
+        };
+
+        let value = serde_json::to_value(&attachment).expect("serialize attachment input");
+
+        assert_eq!(
+            value,
+            json!({
+                "name": "passport.pdf",
+                "cid": "bafybeihash"
+            })
+        );
+    }
+
+    #[test]
+    fn get_attachments_response_serializes_flat_attachment_rows() {
+        let response = GetAttachmentsResponse {
+            attachments: vec![
+                Attachment {
+                    name: "passport.pdf".to_string(),
+                    cid: "bafybeiv1".to_string(),
+                },
+                Attachment {
+                    name: "passport.pdf".to_string(),
+                    cid: "bafybeiv2".to_string(),
+                },
+            ],
+        };
+
+        let value = serde_json::to_value(&response).expect("serialize attachments response");
+
+        assert_eq!(
+            value,
+            json!({
+                "attachments": [
+                    { "name": "passport.pdf", "cid": "bafybeiv1" },
+                    { "name": "passport.pdf", "cid": "bafybeiv2" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn get_attachments_response_schema_exposes_attachment_rows() {
+        let schema = schema_for!(GetAttachmentsResponse);
+        let root = serde_json::to_value(&schema).expect("schema to json");
+
+        assert_eq!(
+            root["properties"]["attachments"]["type"],
+            serde_json::Value::String("array".to_string())
+        );
+        assert!(root["definitions"]["Attachment"]["properties"]["name"].is_object());
+        assert!(root["definitions"]["Attachment"]["properties"]["cid"].is_object());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod attachment;
 pub mod env;
 pub mod ingest;
 pub mod metadata;
@@ -6,21 +7,21 @@ pub mod ownership;
 pub mod register;
 pub mod storage;
 
+pub use attachment::{Attachment, AttachmentInput, GetAttachmentsResponse};
 pub use env::{create_env, create_ownable_env};
 pub use ingest::{
-    require_ownable_event_type, source_matches, OwnableEvent, OwnableEventError,
-    OwnableEventSource,
+    OwnableEvent, OwnableEventError, OwnableEventSource, require_ownable_event_type, source_matches,
 };
 pub use metadata::{
-    derive_rgb_values, get_random_color, package_title_from_name, rgb_hex, Metadata, NFT,
+    Metadata, NFT, derive_rgb_values, get_random_color, package_title_from_name, rgb_hex,
 };
-pub use ownership::{ensure_owner, InfoResponse, OwnableInfo, OwnerAddress};
+pub use ownership::{InfoResponse, OwnableInfo, OwnerAddress, ensure_owner};
 pub use register::{
-    decode_abi, decode_abi_for, encode_abi, require_event_type, EncodePublicEventRequest,
-    PublicEvent, PublicEventError,
+    EncodePublicEventRequest, PublicEvent, PublicEventError, decode_abi, decode_abi_for,
+    encode_abi, require_event_type,
 };
 pub use storage::{
-    load_owned_deps, EmptyApi, EmptyQuerier, IdbStateDump, IdbStorage, MemoryStorage,
+    EmptyApi, EmptyQuerier, IdbStateDump, IdbStorage, MemoryStorage, load_owned_deps,
 };
 
 #[cfg(feature = "macros")]


### PR DESCRIPTION
## Summary
- add the canonical dossier attachment/close surface in `ownable-std`
- add shared attachment types: `AttachmentInput`, `Attachment`, and `GetAttachmentsResponse`
- add proc macros: `ownables_attach`, `ownables_close`, `ownables_query_attachments`, and `ownables_query_closed`
- keep capability detection schema-based and leave `InfoResponse` unchanged

## Canonical Plan
- Run spec: `/home/arnold/Projects/eqty/.runs/2026-06-22_23-57-48_dossier/spec.md`
- Repo plan: `/home/arnold/Projects/eqty/.runs/2026-06-22_23-57-48_dossier/plans/ownable-std.md`

## Verification
- `cargo test --workspace` ✅
- `cargo fmt --all` ✅
- direct repo-local macro/shared-type coverage added in this branch and included in the passing workspace test run

## Temporary Dependencies
- This PR must remain `draft` because the dossier run still requires temporary local filesystem dependencies downstream.
- `ownables-js` is planned to depend on local `ownable-std` / `ownable-std-macros` paths until this repo ships a releasable version with the new dossier surface.
- `ownables-sdk` does not currently require a temporary local dependency by plan, but would if its implementation changes direct Rust consumers before release.

## Upstream Release / Version Replacement
- Downstream repos cannot replace temporary local paths until a releasable `ownable-std` version containing this surface exists.
- Release coordination still needs to resolve the current version skew called out in the plan: repo workspace `0.7.0`, published crate line `0.8.0`, and much older dossier Rust dependencies downstream.

## Release Readiness
- Not release-ready yet.
- No first-publish blocker: this PR updates existing crates rather than introducing a new package.
- Remaining blockers:
  - downstream temporary local dependencies still exist for the run
  - downstream adoption and verification in `ownables-js` are still in flight
  - release/version replacement plan is not settled yet
- Current repo automation uses `release-plz`; the checked-in workflow still publishes with `CARGO_REGISTRY_TOKEN` rather than a new first-publish bootstrap flow.

## Base Branch
- Base branch: `main`
- No non-`main` exception was approved for this run.

## Risks / Follow-up
- The main residual risk is release coordination around the version skew and downstream path-dependency replacement.
- QC should confirm the new standard surface matches the accepted plan and that the recorded verification is sufficient for the added proc macros and shared types.
